### PR TITLE
Add supply chain visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,24 @@ Each part is unpacked to show:
 - **Frontend**: React, TailwindCSS  
 - **Visualization**: D3.js / SVG for interactive trees  
 - **Mapping**: Mapbox GL JS  
-- **Data Layer**: JSON (MVP), Supabase (future)  
-- **Export**: html2pdf or jsPDF for on-demand report generation  
+- **Data Layer**: JSON (MVP), Supabase (future)
+- **Export**: html2pdf or jsPDF for on-demand report generation
+
+## Setup
+
+1. Install dependencies
+
+```bash
+npm install
+```
+
+2. Start the development server
+
+```bash
+npm start
+```
+
+The map view requires a Mapbox access token. Replace `YOUR_MAPBOX_ACCESS_TOKEN` in `src/components/MapView.jsx` with your token.
 
 ---
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+export default {
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+};

--- a/package.json
+++ b/package.json
@@ -3,6 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "echo 'Placeholder for start script'"
+    "start": "vite",
+    "build": "vite build",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "jest": "^29.0.0",
+    "vite": "^4.0.0"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "mapbox-gl": "^2.15.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,21 +1,25 @@
-import React, { useState } from 'react';
-
-// Static list of Tesla Model 3 parts for the sidebar
-const parts = ['Battery', 'Motor', 'Chassis'];
+import React, { useState, useEffect } from 'react';
+import PartTree from './components/PartTree.jsx';
+import MapView from './components/MapView.jsx';
+import ModalDetails from './components/ModalDetails.jsx';
+import WhatIfSimulator from './components/WhatIfSimulator.jsx';
+import { parseSupplyData } from './utils/supplyParser.js';
+import componentsJson from './data/teslaModel3.json';
+import locationsJson from './data/locations.json';
 
 function App() {
-  // Track which part is selected and whether the info modal is visible
+  const [data, setData] = useState({ components: {}, locations: [] });
   const [selectedPart, setSelectedPart] = useState(null);
-  const [showModal, setShowModal] = useState(false);
 
-  // When a part is clicked, open the modal with that part's name
+  useEffect(() => {
+    setData(parseSupplyData(componentsJson, locationsJson));
+  }, []);
+
   const handlePartClick = (part) => {
     setSelectedPart(part);
-    setShowModal(true);
   };
 
-  // Close the modal
-  const closeModal = () => setShowModal(false);
+  const closeModal = () => setSelectedPart(null);
 
   return (
     // Full-height layout split into header, sidebar, and main map area
@@ -30,43 +34,21 @@ function App() {
         {/* Sidebar */}
         <aside className="w-64 bg-gray-100 p-4 overflow-y-auto">
           <h2 className="font-semibold mb-2">Tesla Model 3 Parts</h2>
-          <ul className="space-y-1">
-            {parts.map((part) => (
-              <li key={part}>
-                <button
-                  className="text-blue-600 hover:underline"
-                  onClick={() => handlePartClick(part)}
-                >
-                  {part}
-                </button>
-              </li>
-            ))}
-          </ul>
+          <PartTree data={data.components} onSelect={handlePartClick} />
         </aside>
 
-        {/* Map placeholder */}
-        <main className="flex-1 bg-gray-200 flex items-center justify-center">
-          <div className="text-gray-500">Map Placeholder</div>
+        <main className="flex-1 bg-gray-200">
+          <MapView locations={selectedPart ? selectedPart.locations : data.locations} />
         </main>
       </div>
 
-      {/* Modal overlay */}
-      {showModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-6 rounded shadow-xl w-80">
-            <h3 className="text-lg font-bold mb-2">{selectedPart}</h3>
-            <p className="text-sm text-gray-700">
-              Supply chain details coming soon...
-            </p>
-            <button
-              className="mt-4 text-blue-600 hover:underline"
-              onClick={closeModal}
-            >
-              Close
-            </button>
-          </div>
-        </div>
+      {selectedPart && (
+        <ModalDetails component={selectedPart} onClose={closeModal} />
       )}
+
+      <div className="absolute bottom-4 right-4">
+        <WhatIfSimulator component={selectedPart} />
+      </div>
     </div>
   );
 }

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -1,0 +1,10 @@
+import { parseSupplyData } from '../utils/supplyParser.js';
+
+describe('parseSupplyData', () => {
+  it('maps locations to components', () => {
+    const comps = { components: [{ id: 'a', name: 'A' }] };
+    const locs = { locations: [{ id: 1, componentId: 'a' }] };
+    const result = parseSupplyData(comps, locs);
+    expect(result.components.a.locations.length).toBe(1);
+  });
+});

--- a/src/__tests__/riskEngine.test.js
+++ b/src/__tests__/riskEngine.test.js
@@ -1,0 +1,8 @@
+import { calculateRisk } from '../utils/riskEngine.js';
+
+describe('calculateRisk', () => {
+  it('adds region and material risk', () => {
+    const item = { region: 'Asia', materialType: 'Cobalt' };
+    expect(calculateRisk(item)).toBeGreaterThan(0);
+  });
+});

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,7 +1,35 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import mapboxgl from 'mapbox-gl';
 
-const MapView = () => {
-  return <div>Map View Placeholder</div>;
+mapboxgl.accessToken = 'YOUR_MAPBOX_ACCESS_TOKEN';
+
+const MapView = ({ locations = [] }) => {
+  const mapContainer = useRef(null);
+  const mapRef = useRef(null);
+
+  useEffect(() => {
+    mapRef.current = new mapboxgl.Map({
+      container: mapContainer.current,
+      style: 'mapbox://styles/mapbox/streets-v11',
+      center: [0, 20],
+      zoom: 1.2,
+    });
+    return () => {
+      if (mapRef.current) mapRef.current.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!mapRef.current) return;
+    locations.forEach((loc) => {
+      new mapboxgl.Marker()
+        .setLngLat([loc.lng, loc.lat])
+        .setPopup(new mapboxgl.Popup().setText(loc.name))
+        .addTo(mapRef.current);
+    });
+  }, [locations]);
+
+  return <div ref={mapContainer} className="w-full h-full" />;
 };
 
 export default MapView;

--- a/src/components/ModalDetails.jsx
+++ b/src/components/ModalDetails.jsx
@@ -1,7 +1,32 @@
 import React from 'react';
+import { calculateRisk } from '../utils/riskEngine.js';
 
-const ModalDetails = () => {
-  return <div>Modal Details Placeholder</div>;
+const ModalDetails = ({ component, onClose }) => {
+  if (!component) return null;
+
+  const risk = calculateRisk(component);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+      <div className="bg-white p-6 rounded shadow-xl w-80">
+        <h3 className="text-lg font-bold mb-2">{component.name}</h3>
+        <p className="text-sm mb-2">Risk Score: {risk}</p>
+        {component.locations && component.locations.length > 0 && (
+          <ul className="text-sm list-disc ml-4">
+            {component.locations.map((l) => (
+              <li key={l.id}>{l.name} ({l.region})</li>
+            ))}
+          </ul>
+        )}
+        <button
+          className="mt-4 text-blue-600 hover:underline"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default ModalDetails;

--- a/src/components/PartTree.jsx
+++ b/src/components/PartTree.jsx
@@ -1,7 +1,27 @@
 import React from 'react';
 
-const PartTree = () => {
-  return <div>Part Tree Placeholder</div>;
+const PartTree = ({ data = {}, onSelect }) => {
+  const renderNode = (node) => (
+    <li key={node.id} className="ml-2">
+      <button
+        className="text-blue-600 hover:underline"
+        onClick={() => onSelect && onSelect(node)}
+      >
+        {node.name}
+      </button>
+      {Array.isArray(node.children) && (
+        <ul className="ml-4 list-disc">
+          {node.children.map(renderNode)}
+        </ul>
+      )}
+    </li>
+  );
+
+  return (
+    <ul className="space-y-1">
+      {Object.values(data).map((node) => renderNode(node))}
+    </ul>
+  );
 };
 
 export default PartTree;

--- a/src/components/WhatIfSimulator.jsx
+++ b/src/components/WhatIfSimulator.jsx
@@ -1,7 +1,37 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { calculateRisk } from '../utils/riskEngine.js';
 
-const WhatIfSimulator = () => {
-  return <div>What-If Simulator Placeholder</div>;
+const regions = ['North America', 'Europe', 'Asia'];
+
+const WhatIfSimulator = ({ component }) => {
+  const [region, setRegion] = useState('');
+  if (!component) return null;
+
+  const originalRisk = calculateRisk(component);
+  const simulated = { ...component, region, locations: [{ ...component.locations?.[0], region }] };
+  const newRisk = region ? calculateRisk(simulated) : originalRisk;
+  const diff = newRisk - originalRisk;
+
+  return (
+    <div className="p-2 bg-gray-100 rounded mt-2">
+      <h4 className="font-semibold mb-1">What-If Simulator</h4>
+      <select
+        className="border p-1 mr-2"
+        value={region}
+        onChange={(e) => setRegion(e.target.value)}
+      >
+        <option value="">Select region</option>
+        {regions.map((r) => (
+          <option key={r} value={r}>{r}</option>
+        ))}
+      </select>
+      {region && (
+        <div className="text-sm mt-1">
+          New Risk: {newRisk} ({diff >= 0 ? '+' : ''}{diff})
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default WhatIfSimulator;

--- a/src/data/locations.json
+++ b/src/data/locations.json
@@ -1,3 +1,22 @@
 {
-  "locations": []
+  "locations": [
+    {
+      "id": "loc1",
+      "name": "Nevada Gigafactory",
+      "componentId": "battery",
+      "lat": 39.5,
+      "lng": -119.7,
+      "region": "North America",
+      "materialType": "Lithium"
+    },
+    {
+      "id": "loc2",
+      "name": "Shanghai Plant",
+      "componentId": "motor",
+      "lat": 31.3,
+      "lng": 121.5,
+      "region": "Asia",
+      "materialType": "Rare Earth"
+    }
+  ]
 }

--- a/src/data/teslaModel3.json
+++ b/src/data/teslaModel3.json
@@ -1,6 +1,13 @@
 {
   "components": [
-    { "id": "battery", "name": "Battery" },
+    {
+      "id": "battery",
+      "name": "Battery",
+      "children": [
+        { "id": "cells", "name": "Cells" },
+        { "id": "casing", "name": "Casing" }
+      ]
+    },
     { "id": "motor", "name": "Motor" },
     { "id": "chassis", "name": "Chassis" }
   ]

--- a/src/utils/riskEngine.js
+++ b/src/utils/riskEngine.js
@@ -1,4 +1,31 @@
+const REGION_RISK = {
+  'Asia': 3,
+  'Europe': 2,
+  'North America': 1,
+};
+
+const MATERIAL_RISK = {
+  'Cobalt': 5,
+  'Lithium': 3,
+  'Rare Earth': 4,
+};
+
 export function calculateRisk(item) {
-  // TODO: implement risk calculation
-  return null;
+  if (!item) return 0;
+
+  let score = 0;
+
+  if (item.region && REGION_RISK[item.region]) {
+    score += REGION_RISK[item.region];
+  }
+
+  if (item.materialType && MATERIAL_RISK[item.materialType]) {
+    score += MATERIAL_RISK[item.materialType];
+  }
+
+  if (Array.isArray(item.locations)) {
+    return item.locations.reduce((sum, loc) => sum + calculateRisk(loc), score);
+  }
+
+  return score;
 }

--- a/src/utils/supplyParser.js
+++ b/src/utils/supplyParser.js
@@ -1,4 +1,24 @@
-export function parseSupplyData(data) {
-  // TODO: implement supply data parsing
-  return data;
+export function parseSupplyData(componentsJson = {}, locationsJson = {}) {
+  const components = Array.isArray(componentsJson.components)
+    ? componentsJson.components
+    : [];
+  const locations = Array.isArray(locationsJson.locations)
+    ? locationsJson.locations
+    : [];
+
+  const byId = {};
+  components.forEach((comp) => {
+    byId[comp.id] = { ...comp, locations: [] };
+  });
+
+  locations.forEach((loc) => {
+    if (byId[loc.componentId]) {
+      byId[loc.componentId].locations.push(loc);
+    }
+  });
+
+  return {
+    components: byId,
+    locations,
+  };
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up Vite and Jest config
- add initial data for components and locations
- implement supply parser and risk engine
- flesh out MapView, PartTree, ModalDetails, WhatIfSimulator components
- wire components together in App
- basic tests for utils
- document setup in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68504576843c832a8034c9eec0551b23