### PR TITLE
Enable standalone HTML and refresh UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ Each part is unpacked to show:
 
 ## Setup
 
+This project can run without a build step by opening `public/index.html` directly.
+Ensure you have an internet connection as React, Tailwind and Mapbox are loaded from CDNs.
+Edit the `MAPBOX_TOKEN` variable in that file with your Mapbox access token.
+
+For development with Vite:
+
 1. Install dependencies
 
 ```bash
 npm install
 ```
 
-2. Create a `.env` file in the project root and add your Mapbox token:
-
-```bash
-echo "VITE_MAPBOX_TOKEN=your_mapbox_access_token" > .env
-```
-
-3. Start the development server
+2. Start the development server
 
 ```bash
 npm start

--- a/public/index.html
+++ b/public/index.html
@@ -4,9 +4,18 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OriginPath</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      href="https://unpkg.com/mapbox-gl@2.15.0/dist/mapbox-gl.css"
+      rel="stylesheet"
+    />
   </head>
-  <body>
+  <body class="bg-gray-50 text-gray-800">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script>
+      // Set your Mapbox token here
+      window.MAPBOX_TOKEN = '';
+    </script>
+    <script type="module" src="../src/main.jsx"></script>
   </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'https://esm.sh/react@18.2.0';
 import PartTree from './components/PartTree.jsx';
 import MapView from './components/MapView.jsx';
 import ModalDetails from './components/ModalDetails.jsx';
@@ -25,19 +25,19 @@ function App() {
     // Full-height layout split into header, sidebar, and main map area
     <div className="h-screen flex flex-col font-sans">
       {/* Header */}
-      <header className="bg-gray-800 text-white p-4">
-        <h1 className="text-xl font-bold">OriginPath</h1>
+      <header className="bg-gradient-to-r from-gray-900 to-gray-700 text-white p-4 shadow">
+        <h1 className="text-xl font-semibold tracking-wide">OriginPath</h1>
       </header>
 
       {/* Sidebar and map container */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar */}
-        <aside className="w-64 bg-gray-100 p-4 overflow-y-auto">
+        <aside className="w-64 bg-white border-r border-gray-200 p-4 overflow-y-auto">
           <h2 className="font-semibold mb-2">Tesla Model 3 Parts</h2>
           <PartTree data={data.components} onSelect={handlePartClick} />
         </aside>
 
-        <main className="flex-1 bg-gray-200">
+        <main className="flex-1 bg-gray-100">
           <MapView locations={selectedPart ? selectedPart.locations : data.locations} />
         </main>
       </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'https://esm.sh/react@18.2.0';
 
 const Header = () => (
   <header className="bg-gray-800 text-white p-4">Header Placeholder</header>

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useRef } from 'react';
-import mapboxgl from 'mapbox-gl';
+import React, { useEffect, useRef } from 'https://esm.sh/react@18.2.0';
+import mapboxgl from 'https://esm.sh/mapbox-gl@2.15.0';
 
-mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
+mapboxgl.accessToken = window.MAPBOX_TOKEN || '';
 
 const MapView = ({ locations = [] }) => {
   const mapContainer = useRef(null);

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'https://esm.sh/react@18.2.0';
 
 const Modal = () => (
   <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">

--- a/src/components/ModalDetails.jsx
+++ b/src/components/ModalDetails.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'https://esm.sh/react@18.2.0';
 import { calculateRisk } from '../utils/riskEngine.js';
 
 const ModalDetails = ({ component, onClose }) => {

--- a/src/components/PartTree.jsx
+++ b/src/components/PartTree.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from 'https://esm.sh/react@18.2.0';
 
 const PartTree = ({ data = {}, onSelect }) => {
   const renderNode = (node) => (

--- a/src/components/WhatIfSimulator.jsx
+++ b/src/components/WhatIfSimulator.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState } from 'https://esm.sh/react@18.2.0';
 import { calculateRisk } from '../utils/riskEngine.js';
 
 const regions = ['North America', 'Europe', 'Asia'];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
+import React from 'https://esm.sh/react@18.2.0';
+import ReactDOM from 'https://esm.sh/react-dom@18.2.0/client';
 import App from './App.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(


### PR DESCRIPTION
## Summary
- load React, Tailwind and Mapbox from CDNs so public/index.html works standalone
- tweak App layout for a minimal aesthetic
- use CDN imports in React components
- document running without build

## Testing
- `npm test --silent` *(fails: jest-environment-jsdom missing)*

------
https://chatgpt.com/codex/tasks/task_e_685061ce1824832ab245912d1c03b23e